### PR TITLE
Add ability to add arbitrary conditions to role assignments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,9 @@ property on the plugin's properties screen (through ZMI).
 Each line represents a mapping from an header value (using a regexp match) to
 one or more roles. The format is as follows::
 
-    http_header_name; regular expression; role[, role ...]
+    http_header_name; regular expression; role[, role ...] ; TALES
+
+The TALES field allows arbitrary expressions to be added to role mappings, for example to check other HTTP headers.
 
 Assign groups, not roles
 ------------------------
@@ -33,7 +35,7 @@ Assign groups, not roles
 This plugin can be used to assign groups instead of roles if used as a
 *group plugin* instead of a role plugin::
 
-    http_header_name; regular expression; group[, group ...]
+    http_header_name; regular expression; group[, group ...] ; TALES
 
 Groups plugin is not activated by default.
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,7 @@ Changelog
 0.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+* Add TALES field to assignments, allowing users to provide arbitrary conditions [matthewwilkes]
 
 
 0.4.1 (2014-07-10)

--- a/src/Products/AutoRoleFromHostHeader/plugins/AutoRole.py
+++ b/src/Products/AutoRoleFromHostHeader/plugins/AutoRole.py
@@ -61,7 +61,12 @@ class AutoRole(BasePlugin):
         self._compiled = compiled = []
         for line in self.match_roles:
             try:
-                header_name, regexp, roles, condition = line.split(';')
+                values = line.split(';')
+                if len(values) == 3:
+                    # If there isn't a condition, pretend the condition was
+                    # something that's always true
+                    values = values + ['python:True',]
+                header_name, regexp, roles, condition = values
                 roles = [r.strip() for r in roles.split(',')]
                 roles = set(filter(None, roles))
                 if not roles:

--- a/src/Products/AutoRoleFromHostHeader/plugins/AutoRole.py
+++ b/src/Products/AutoRoleFromHostHeader/plugins/AutoRole.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from Acquisition import aq_parent, aq_inner
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from Globals import InitializeClass
 from Products.AutoRoleFromHostHeader.interfaces import ConfigurationChangedEvent
@@ -102,8 +103,8 @@ class AutoRole(BasePlugin):
             return []
 
         result = set()
-        context = engine.getContext(request=request, portal=self._getPAS().aq_parent.aq_inner)
-        print self._getPAS().aq_parent.aq_inner
+        portal = aq_inner(aq_parent(self._getPAS()))
+        context = engine.getContext(request=request, portal=portal)
         for header_name, regexp, roles, condition in self._compiled:
             condition = engine.compile(condition)
             header = request.get(header_name)
@@ -138,8 +139,8 @@ class AutoRole(BasePlugin):
         if not self._compiled:
             return {}
         
-        context = engine.getContext(request=request, portal=self._getPAS().aq_parent.aq_inner)
-        site = self._getPAS().aq_parent.aq_inner
+        portal = aq_inner(aq_parent(self._getPAS()))
+        context = engine.getContext(request=request, portal=portal)
         for header_name, regexp, roles, condition in self._compiled:
             condition = engine.compile(condition)
             header = request.get(header_name)

--- a/src/Products/AutoRoleFromHostHeader/tests/testAutoRole.py
+++ b/src/Products/AutoRoleFromHostHeader/tests/testAutoRole.py
@@ -52,12 +52,12 @@ class TestAutoRole(unittest.TestCase, IRolesPlugin_conformance):
         helper = self._makeOne()
         request = FakeRequest()
 
-        helper._updateProperty('match_roles', [r'REMOTE_ADDR;127\.0\.0\.;Manager,Member'])
+        helper._updateProperty('match_roles', [r'REMOTE_ADDR;127\.0\.0\.;Manager,Member;python:True'])
         self.assertEqual( helper.getRolesForPrincipal( None, request ), ['Member','Manager'])
 
-        helper._updateProperty('match_roles', [r'REMOTE_ADDR;127\.0\.0\.;Manager',
-                                               r'REMOTE_ADDR;1\.28\.;Member',
-                                               r'HTTP_USER_AGENT;Mozilla\/5\.0;Member,Manager'])
+        helper._updateProperty('match_roles', [r'REMOTE_ADDR;127\.0\.0\.;Manager;python:True',
+                                               r'REMOTE_ADDR;1\.28\.;Member;python:True',
+                                               r'HTTP_USER_AGENT;Mozilla\/5\.0;Member,Manager;python:True'])
         request.REMOTE_ADDR='1.28.1.1'
         request.HTTP_USER_AGENT='Funny 1.0'
         self.assertEqual( helper.getRolesForPrincipal( None, request ), ['Member'])
@@ -76,8 +76,8 @@ class TestAutoRole(unittest.TestCase, IRolesPlugin_conformance):
         helper.anon_only = False
 
         # Test for invalid ip address
-        helper._updateProperty('match_roles', [r'REMOTE_ADDR;10\.0\.0\.;Manager',
-                                               r'REMOTE_ADDR;10\.1\.0\.;Manager'])
+        helper._updateProperty('match_roles', [r'REMOTE_ADDR;10\.0\.0\.;Manager;python:True',
+                                               r'REMOTE_ADDR;10\.1\.0\.;Manager;python:True'])
         request.REMOTE_ADDR = 'invalidip'
         self.assertEqual( helper.getRolesForPrincipal( None, request ), [])
         request.REMOTE_ADDR = ''
@@ -97,7 +97,7 @@ class TestAutoRole(unittest.TestCase, IRolesPlugin_conformance):
         helper = self._makeOne()
         request = FakeRequest()
 
-        helper._updateProperty('match_roles', [r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member'])
+        helper._updateProperty('match_roles', [r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member;python:True'])
         request.REMOTE_ADDR = '10.0.100.1'
         self.assertEqual(helper.extractCredentials( request ), {'AutoRole':True})
 
@@ -112,7 +112,7 @@ class TestAutoRole(unittest.TestCase, IRolesPlugin_conformance):
         helper = self._makeOne()
         request = FakeRequest()
 
-        helper._updateProperty('match_roles', [r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member'])
+        helper._updateProperty('match_roles', [r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member;python:True'])
 
         request.REMOTE_ADDR = 'invalidip'
         self.assertEqual( helper.extractCredentials( request ), {})

--- a/src/Products/AutoRoleFromHostHeader/tests/testCompiler.py
+++ b/src/Products/AutoRoleFromHostHeader/tests/testCompiler.py
@@ -16,15 +16,15 @@ class TestCompiler(unittest.TestCase):
 
     def testTwoRoles(self):
         plugin = self._makeOne(match_roles=[r'REMOTE_ADDR;127\.0\.0\.;Manager,Member'])
-        self.assertEqual(compiled(plugin), [('REMOTE_ADDR', '127\\.0\\.0\\.', set(['Member', 'Manager']))])
+        self.assertEqual(compiled(plugin), [('REMOTE_ADDR', '127\\.0\\.0\\.', set(['Member', 'Manager']), 'python:True')])
 
     def testDuplicateRole(self):
         plugin = self._makeOne(match_roles=[r'REMOTE_ADDR;127\.0\.0\.;Manager,Manager'])
-        self.assertEqual(compiled(plugin), [('REMOTE_ADDR', '127\\.0\\.0\\.', set(['Manager']))])
+        self.assertEqual(compiled(plugin), [('REMOTE_ADDR', '127\\.0\\.0\\.', set(['Manager']), 'python:True')])
 
     def testWhitespace(self):
         plugin = self._makeOne(match_roles=[r'REMOTE_ADDR;127\.0\.0\.; Manager, Member'])
-        self.assertEqual(compiled(plugin), [('REMOTE_ADDR', '127\\.0\\.0\\.', set(['Manager', 'Member']))])
+        self.assertEqual(compiled(plugin), [('REMOTE_ADDR', '127\\.0\\.0\\.', set(['Manager', 'Member']), 'python:True')])
 
     def testNoIp(self):
         plugin = self._makeOne(match_roles=[':Manager'])

--- a/src/Products/AutoRoleFromHostHeader/tests/testEvent.py
+++ b/src/Products/AutoRoleFromHostHeader/tests/testEvent.py
@@ -22,12 +22,12 @@ class TestEvent(unittest.TestCase):
     def testChangingHEaderMatchFiresEvent(self):
         plugin = self._makeOne()
         self.assertEqual(eventtesting.getEvents(), [])
-        plugin.manage_changeProperties(match_roles=[r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member'])
+        plugin.manage_changeProperties(match_roles=[r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member;python:True'])
         self.assertEqual(len(eventtesting.getEvents()), 1)
         event = eventtesting.getEvents()[0]
         self.assertEqual(event.__class__.__name__, 'ConfigurationChangedEvent')
         self.assertEqual(event.object, plugin)
-        self.assertEqual(event.object.match_roles, (r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member',))
+        self.assertEqual(event.object.match_roles, (r'REMOTE_ADDR;^10\.0\.(100|101)\.;Authenticated,Member;python:True',))
 
     def testChangingTitleFiresNoEvent(self):
         plugin = self._makeOne()


### PR DESCRIPTION
Hi,

We have a situation where we have rather complex headers coming from upstream, specifically we have headers that determine role but also headers that determine scoping of those roles. The assignment is only valid if a key in another header matches a key in the site being proxied to. Rather than have the logic for each site be contained in the upstream layer, this patch allows us to provide TALES expressions to further validate assignments.

For example:

```
'HTTP_X_ROLE;FOO_ROLE;FOO_ROLE;python:request.getHeader("X-Portal")==portal.id',
```
