### PR TITLE
Zope 4 compatibility: Replaced broken imports of InitializeClass

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Zope 4 compatibility: Replaced broken imports of InitializeClass.
+  [reinhardt]
 
 
 1.0.0 (2015-06-05)

--- a/src/Products/AutoRoleFromHostHeader/plugins/AutoRole.py
+++ b/src/Products/AutoRoleFromHostHeader/plugins/AutoRole.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from Acquisition import aq_parent, aq_inner
+from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
-from Globals import InitializeClass
 from logging import getLogger
 from Products.AutoRoleFromHostHeader.interfaces import ConfigurationChangedEvent
 from Products.PageTemplates.Expressions import createZopeEngine


### PR DESCRIPTION
The Globals module had been deprecated and now has gone away in Zope 4. The recommended way to go is to import from AccessControl.class_init instead.