### PR TITLE
add empty uninstall profile

### DIFF
--- a/src/Products/AutoRoleFromHostHeader/configure.zcml
+++ b/src/Products/AutoRoleFromHostHeader/configure.zcml
@@ -12,6 +12,14 @@
     provides="Products.GenericSetup.interfaces.EXTENSION"
     />
 
+  <genericsetup:registerProfile
+    name="uninstall"
+    title="AutoRole HTTP Header PAS Plugin"
+    directory="profiles/uninstall"
+    description="PAS plugin assigning roles based on HTTP Header match."
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
+
   <genericsetup:importStep
     name="autorole"
     title="AutoRole HTTP Header PAS Plugin"


### PR DESCRIPTION
Closes #5
In the control panel, there's a warning "the product cannot be uninstalled", this PR should fix it with an empty profile